### PR TITLE
fix some bugs

### DIFF
--- a/ch04/README.md
+++ b/ch04/README.md
@@ -264,7 +264,7 @@ reference: [Why the size of a pointer is 4bytes in C++](http://stackoverflow.com
 sizeof x + y      // sizeof(x+y)
 sizeof p->mem[i]  // sizeof(p->mem[i])
 sizeof a < b      // sizeof(a) < b
-sizeof f()        // compile successfully.
+sizeof f()        // compile error if the return of f() is void. If f() has a return value, compile successfully.
 ```
 
 -----


### PR DESCRIPTION
According to the question of exercise 4.15, the point pi should be 0.  
In the exercise 4.30, the parenthesize `sizeof f()` can be compiled successfully. The sizeof operator returns  the size, in bytes, of an expression or a type name.  
PS. I forget the return of f(). If the return of f() is void, compile error. OMG~~~
