### PR TITLE
Update ex11_3_4.cpp

### DIFF
--- a/ch11/ex11_3_4.cpp
+++ b/ch11/ex11_3_4.cpp
@@ -20,7 +20,7 @@ void word_count_pro(std::map<std::string, int> &m)
     for(std::string word;   std::cin >> word; /* */)
     {
         for(auto& ch : word)    ch = std::tolower(ch);
-        std::remove_if(word.begin(), word.end(), ispunct);
+        std::erase(std::remove_if(word.begin(), word.end(), ispunct), word.end());
         ++m[word];
 
         for (const auto &e : m)


### PR DESCRIPTION
之前的remove_if函数并不能真正删除单词后面的标点符号，修改之后可删除。
