### PR TITLE
Fix 13.8

### DIFF
--- a/ch13/ex13_08.h
+++ b/ch13/ex13_08.h
@@ -25,9 +25,7 @@ public:
     HasPtr(const HasPtr& hp) : ps(new std::string(*hp.ps)), i(hp.i) {}
     HasPtr& operator=(const HasPtr& hp)
     {
-        std::string* new_ps = new std::string(*hp.ps);
-        delete ps;
-        ps = new_ps;
+        *ps = *hp.ps;
         i = hp.i;
         return *this;
     }


### PR DESCRIPTION
"copy the object to which ps points" is enough. No need to reallocate.