### PR TITLE
Update ex16_28_unique_ptr.h

### DIFF
--- a/ch16/ex16_28_unique_ptr.h
+++ b/ch16/ex16_28_unique_ptr.h
@@ -45,7 +45,8 @@ public:
 
     void reset(T* q = nullptr) noexcept
     {
-        deleter_(q);
+        deleter_(q);        // Error: should relase old obj pointed by ptr
+        // deleter_(ptr);   // Corrected !!
         ptr_ = q;
     }
 


### PR DESCRIPTION
源代码中reset()释放错误的内存

Reset ()  release the wrong memory in the source code