### PR TITLE
Fix #211

### DIFF
--- a/ch16/ex16_12_blob.h
+++ b/ch16/ex16_12_blob.h
@@ -150,7 +150,7 @@ template <typename T> BlobPtr<T> Blob<T>::begin()
 
 template <typename T> BlobPtr<T> Blob<T>::end()
 {
-    return BlobPtr<T>(*this, data->size());
+    return BlobPtr<T>(*this, data->size() - 1);
 }
 
 template <typename T> ConstBlobPtr<T> Blob<T>::cbegin() const
@@ -160,7 +160,7 @@ template <typename T> ConstBlobPtr<T> Blob<T>::cbegin() const
 
 template <typename T> ConstBlobPtr<T> Blob<T>::cend() const
 {
-    return ConstBlobPtr<T>(*this, data->size());
+    return ConstBlobPtr<T>(*this, data->size() - 1);
 }
 
 template <typename T> inline void Blob<T>::pop_back()


### PR DESCRIPTION
Change `curr` initialized of `BlobPtr` from `data->size()` to `data->size() - 1`, avoiding `std::out_of_range`.

Tested using follow code:
```cpp
#include "ex16_12_blob.h"
#include <iostream>
#include <string>

int main()
{
    Blob<std::string> sb{"a", "b", "c"};

    auto p1{sb.end()};
    std::cout << p1.deref() << std::endl;

    auto p2{sb.cend()};
    std::cout << *p2 << std::endl;
}
```
Fixed.