### PR TITLE
Update ex7_53.h

### DIFF
--- a/ch07/ex7_53.h
+++ b/ch07/ex7_53.h
@@ -13,7 +13,7 @@ class Debug {
 public:
     constexpr Debug(bool b = true) : rt(b), io(b), other(b) {}
     constexpr Debug(bool r, bool i, bool o) : rt(r), io(i), other(0) {}
-    constexpr bool any() { return rt || io || other; }
+    constexpr bool any() const { return rt || io || other; }
 
     void set_rt(bool b) { rt = b; }
     void set_io(bool b) { io = b; }


### PR DESCRIPTION
Made any() a const member function

The original code would not compile in C++ 14+ and would give the error

`error: passing ‘const Debug’ as ‘this’ argument discards qualifiers [-fpermissive]`